### PR TITLE
fix composer module name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "Creare/CreareSEO",
+    "name": "creare/creare-seo",
     "type": "magento-module",
     "homepage": "http://www.magentocommerce.com/magento-connect/creare-seo.html",
     "description": "This extension provides fixes and features to Magento that will help improve its overall SEO performance.",


### PR DESCRIPTION
fix composer module name according to packagist error message: The package name Creare/CreareSEO is invalid, it should not contain uppercase characters. We suggest using creare/creare-seo instead.