### PR TITLE
offers within a "grouped product" setting

### DIFF
--- a/app/design/frontend/base/default/template/creareseo/product/schema.phtml
+++ b/app/design/frontend/base/default/template/creareseo/product/schema.phtml
@@ -3,7 +3,6 @@ $_helper = $this->helper('catalog/output');
 $_product = $this->getProduct();
 $_i = 1;
 $_totalAverageRating = 0;
-
 ?>
 <!-- Product Schema added by CreareSEO -->
 <script type="application/ld+json">
@@ -15,19 +14,44 @@ $_totalAverageRating = 0;
   "image": "<?php echo Mage::getModel('catalog/product_media_config')->getMediaUrl($_product->getImage()) ?>",
   "sku": "<?php echo $this->cleanString($_product->getSku()) ?>",
   "url": "<?php echo $_product->getProductUrl() ?>",
-  "offers": {
+  "offers": [  
     <?php if($_product->getTypeId() === 'bundle') : ?>
-    <?php $_bundleObject = Mage::getModel('bundle/product_price') ?>
-    "@type": "AggregateOffer",
-    "lowPrice": "<?php echo $_bundleObject->getTotalPrices($_product,'min',1) ?>",
-    "highPrice": "<?php echo $_bundleObject->getTotalPrices($_product,'max',1) ?>",
+    {
+    	<?php $_bundleObject = Mage::getModel('bundle/product_price') ?>
+	    "@type": "AggregateOffer",
+	    "lowPrice": "<?php echo $_bundleObject->getTotalPrices($_product,'min',1) ?>",
+	    "highPrice": "<?php echo $_bundleObject->getTotalPrices($_product,'max',1) ?>",
+	    "availability": "<?php echo ($_product->isAvailable() ? 'InStock' : 'OutOfStock') ?>",
+    	"priceCurrency": "<?php echo $this->getCurrency() ?>"
+  	}
+    <?php elseif($_product->getTypeId() === 'grouped') :  ?>    
+    	<?php $_associatedProducts = $_product->getTypeInstance(true)->getAssociatedProducts($_product); ?>	
+    	<?php $_hasAssociatedProducts = count($_associatedProducts) > 0; $notfirst=0;?>
+	    <?php foreach ($_associatedProducts as $_associtem): ?>	
+	    <?php if($notfirst){ echo " ," ;} ?> <?php $notfirst=1; ?>
+		{
+	    	<?php $_finalPriceInclTax = $this->helper('tax')->getPrice($_associtem, $_associtem->getFinalPrice(), true) ?>
+	    	"@type": "Offer",
+	    	"availability": "<?php echo ($_associtem->isAvailable() ? 'InStock' : 'OutOfStock') ?>",
+	    	"itemOffered": {
+	    			"sku": "<?php echo $_associtem->getSku() ?>"	,
+	    			"name": "<?php echo $_associtem->getName() ?>",
+	    	},
+	    	"priceCurrency": "<?php echo $this->getCurrency() ?>",
+	    	"price": "<?php echo $_finalPriceInclTax ?>"
+		} 
+	    <?php endforeach; ?>
+	    	
     <?php else: ?>
-    "@type": "Offer",
-    "price": "<?php echo number_format(Mage::helper('creareseocore')->getProductStartingprice($_product),2) ?>",
+    {
+    	"@type": "Offer",
+    	"price": "<?php echo number_format(Mage::helper('creareseocore')->getProductStartingprice($_product),2) ?>",
+    	"availability": "<?php echo ($_product->isAvailable() ? 'InStock' : 'OutOfStock') ?>",
+    	"priceCurrency": "<?php echo $this->getCurrency() ?>"
+    }
     <?php endif ?>
-    "availability": "<?php echo ($_product->isAvailable() ? 'InStock' : 'OutOfStock') ?>",
-    "priceCurrency": "<?php echo $this->getCurrency() ?>"
-  }<?php if ($this->getReviewsCount()) : ?>,
+   ]
+  <?php if ($this->getReviewsCount()) : ?>,
   "review": [
     <?php foreach ($this->_productReviews as $review) : ?>
     {


### PR DESCRIPTION
the current code for a grouped product will create incorrectly an offer of price 0 (the grouped product has no price)

"offers": {
"@type": "Offer",
"price": "0.00",
"availability": "InStock",
"priceCurrency": "GBP"
}}

My changes instead create an "offers" loop over the associated product

"offers": [
{
"@type": "Offer",
"availability": "InStock",
"itemOffered": {
"sku": "3332176" ,
"name": "my product name"
},
"priceCurrency": "GBP",
"price": "12.7"
} 
]


I'm pretty sure it does not cover all the possible "grouped product" scenarios when it comes to availability and prices etc. but it does generate offers for my scenario. Hopefully someone with more experience of all the possible ways to use grouped products can make it more general.

I suspect something similar needs to be done with reviews but I haven't changed that yet

also, theres a stupidly inelegant way to deal with not putting an end comma in the loop - yes, was too lazy too think :)